### PR TITLE
Replace hardcoded delimiter with a parameter

### DIFF
--- a/ConvertFrom-FixedWidth/functions/ConvertFrom-FixedWidth.ps1
+++ b/ConvertFrom-FixedWidth/functions/ConvertFrom-FixedWidth.ps1
@@ -1,7 +1,8 @@
 function ConvertFrom-FixedWidth {
     Param(
         [parameter(Mandatory = $true)] [object] $FixedWidthTableText,
-        [parameter(Mandatory = $true)] [object] $ColumnIndexArray
+        [parameter(Mandatory = $true)] [object] $ColumnIndexArray,
+        [parameter(Mandatory = $false)] [string] $Delimiter = ","
     )
 
     $columns = $ColumnIndexArray | Sort-Object    
@@ -17,7 +18,7 @@ function ConvertFrom-FixedWidth {
             $currentIndex = $_
 
             if ($firstColumn -ne $true) {
-                $newLine = $newLine + ","
+                $newLine = $newLine + $Delimiter
             }
 
             $newLine = $newLine + $line.Substring($priorIndex, $currentIndex - $priorIndex).Trim()
@@ -26,11 +27,11 @@ function ConvertFrom-FixedWidth {
             $firstColumn = $false
         }
 
-        $newLine = $newLine +"," + $_.Substring($currentIndex, $_.Length-$currentIndex).Trim()
+        $newLine = $newLine + $Delimiter + $_.Substring($currentIndex, $_.Length-$currentIndex).Trim()
         $newLine
     }
 
-    $converted = $delimited | ConvertFrom-Csv
+    $converted = $delimited | ConvertFrom-Csv -Delimiter $Delimiter
 
     return $converted
 }


### PR DESCRIPTION
Replaces the hardcoded comma as a delimiter, and pass it along to Convert-FromCsv.

To be used in cases where the fixedwidth data contains a comma.

Fixes #1 